### PR TITLE
Find root protoplasm.js anywhere.

### DIFF
--- a/src/protoplasm.js
+++ b/src/protoplasm.js
@@ -83,7 +83,7 @@ if (typeof Protoplasm == 'undefined') {
 				}
 
 				var js = /protoplasm(_[a-z]*)?\.js(\?.*)?$/;
-				$$('head script[src]').findAll(function(s) {
+				$$('html script[src]').findAll(function(s) {
 					return s.src.match(js);
 				}).each(function(s) {
 					var matches = s.src.match(js),


### PR DESCRIPTION
Common practice is to take as much javascript out of the head tag as possible. Protoplasm still needs to find itself.
